### PR TITLE
Rename from enriched-data to generated-data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ __pycache__/
 pytestdebug.log
 Gemfile.lock
 .ruby-version
-enriched-data/*
+generated-data/*

--- a/enriched-data/README.md
+++ b/enriched-data/README.md
@@ -1,4 +1,0 @@
-# Enriched Data
-
-This directory contains the serialised data collected by the
-[Enrichers](/enrichers/)

--- a/enrichers/github/README.md
+++ b/enrichers/github/README.md
@@ -23,7 +23,7 @@ GitHub and export it into the shell you want to run the commands from
 
     ./enrichers/github/github-gatherer -o GITHUB_ORGANIZATION_NAME
 
-You can view the gathered data in the `enriched-data` directory
+You can view the gathered data in the `generated-data` directory
 
 ### Running the loader
 

--- a/enrichers/github/github-gatherer
+++ b/enrichers/github/github-gatherer
@@ -66,7 +66,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--output",
         type=str,
-        default="enriched-data/github-output.yaml",
+        default="generated-data/github-output.yaml",
         help="The file to write output to",
     )
 

--- a/enrichers/github/github-loader
+++ b/enrichers/github/github-loader
@@ -145,7 +145,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--datafile",
         type=str,
-        default="enriched-data/github-output.yaml",
+        default="generated-data/github-output.yaml",
         help="File containing the GitHub metadata. Stored as YAML",
     )
 

--- a/enrichers/puppetforge/puppetforge-gatherer
+++ b/enrichers/puppetforge/puppetforge-gatherer
@@ -8,7 +8,7 @@ PuppetForge.user_agent = "OrgGraph PuppetForge Enricher/0.1.0"
 
 
 options = {}
-options[:output] = 'enriched-data/puppetforge-output.yaml'
+options[:output] = 'generated-data/puppetforge-output.yaml'
 
 OptionParser.new do |opts|
   opts.banner = "Usage: #{APP_NAME} [--output output.yaml] <PUPPETFORGE_USERNAME> [PUPPETFORGE_USERNAME_2]"

--- a/generated-data/README.md
+++ b/generated-data/README.md
@@ -1,0 +1,3 @@
+# Generated Data
+
+This directory contains generated node data. Any edits made will be lost


### PR DESCRIPTION
The name 'generated-data' is more immediately understandable. It will
also become the location of data we're building from our
own local source too so enriched is no longer appropriate